### PR TITLE
Improve documentation and robustness of log-conformation viscoelastic solver

### DIFF
--- a/src-local/log-conform-viscoelastic-scalar-2D.h
+++ b/src-local/log-conform-viscoelastic-scalar-2D.h
@@ -233,6 +233,18 @@ arrays not related to the grid. */
 typedef struct { double x, y;}   pseudo_v;
 typedef struct { pseudo_v x, y;} pseudo_t;
 
+// Function to initialize pseudo_v
+static inline void init_pseudo_v(pseudo_v *v, double value) {
+    v->x = value;
+    v->y = value;
+}
+
+// Function to initialize pseudo_t
+static inline void init_pseudo_t(pseudo_t *t, double value) {
+    init_pseudo_v(&t->x, value);
+    init_pseudo_v(&t->y, value);
+}
+
 static void diagonalization_2D (pseudo_v * Lambda, pseudo_t * R, pseudo_t * A)
 {
   /**
@@ -293,11 +305,7 @@ tensor $\mathbf{A}$). In an Oldroyd-B viscoelastic fluid, the model is
 $$ 
 \partial_t \mathbf{A} = -\frac{\mathbf{f}_r (\mathbf{A})}{\lambda}
 $$
-
-The implementation below assumes that the values of $\Psi$ and
-$\conform_p$ are never needed simultaneously. This means that $\conform_p$ can
-be used to store (temporarily) the values of $\Psi$ (i.e. $\Psi$ is
-just an alias for $\conform_p$). */
+*/
 
 event tracer_advection(i++)
 {
@@ -337,8 +345,20 @@ event tracer_advection(i++)
     tensor, $\Lambda$. */
 
     pseudo_v Lambda;
+    init_pseudo_v(&Lambda, 0.0); 
     pseudo_t R;
+    init_pseudo_t(&R, 0.0);
     diagonalization_2D (&Lambda, &R, &A);
+
+    /*
+    Check for negative eigenvalues -- this should never happen. If it does, print the location and value of the offending eigenvalue.
+    Please report this bug by opening an issue on the GitHub repository. 
+    */
+    if (Lambda.x <= 0. || Lambda.y <= 0.) {
+      fprintf(ferr, "Negative eigenvalue detected: Lambda.x = %g, Lambda.y = %g\n", Lambda.x, Lambda.y);
+      fprintf(ferr, "x = %g, y = %g, f = %g\n", x, y, f[]);
+      exit(1);
+    }
     
     /**
     $\Psi = \log \mathbf{A}$ is easily obtained after diagonalization, 

--- a/src-local/log-conform-viscoelastic-scalar-3D.h
+++ b/src-local/log-conform-viscoelastic-scalar-3D.h
@@ -40,7 +40,7 @@
 /**
  * # TODO: (non-critical, non-urgent)
  * axi compatibility is not there. This will not be fixed. To use axi, please use: [log-conform-viscoelastic-scalar-2D.h](log-conform-viscoelastic-scalar-2D.h) for a scalar formulation, or better yet, use [log-conform-viscoelastic.h](log-conform-viscoelastic.h) which is more efficient.
- * I have (wherever I could) use the metric terms: cm and fm. Of course, that alone does not guarentee axi compatibility. Proposed steps to do: 
+ * I have (wherever I could) used the metric terms: cm and fm. Of course, that alone does not guarentee axi compatibility. Proposed steps to do: 
  * - [ ] enfore all tensors and make the code generally compatible using foreach_dimensions
  * - [ ] use metric terms: cm and fm.
 */

--- a/src-local/log-conform-viscoelastic-scalar-3D.h
+++ b/src-local/log-conform-viscoelastic-scalar-3D.h
@@ -1,12 +1,12 @@
 /** Title: log-conform-viscoelastic-3D.h
-# Version: 2.1
+# Version: 2.2
 # Main feature 1: A exists in across the domain and relaxes according to \lambda. The stress only acts according to G.
 # Main feature 2: This is the 3D implementation of [log-conform-viscoelastic-scalar-2D.h](log-conform-viscoelastic-scalar-2D.h).
 
 # Author: Vatsal Sanjay
 # vatsalsanjay@gmail.com
 # Physics of Fluids
-# Updated: Oct 29, 2024
+# Updated: Nov 3, 2024
 
 # change log: Oct 19, 2024 (v1.0)
 - 3D implementation
@@ -30,6 +30,13 @@
 
 # change log: Oct 29, 2024 (v2.1)
 - Added some initialization functions for pseudo_v and pseudo_t and their 3D counterparts.
+
+# change log: Nov 3, 2024 (v2.2)
+- Refactored tensor operations to use intermediate tensor structure A for improved clarity and maintainability
+- Unified A-tensor-based approach throughout the code for consistent tensor manipulation
+- Added explicit symmetry enforcement in tensor operations
+- Improved readability by separating tensor transformation steps
+- Enhanced extensibility for future tensor-only implementations
 */
 
 /** The code is same as http://basilisk.fr/src/log-conform.h but 
@@ -848,30 +855,48 @@ event tracer_advection(i++)
     Lambda.z = exp(Lambda.z);
 
     // Reconstruct A using A = R * diag(Lambda) * R^T
-    A11[] = Lambda.x * sq(R.x.x) + Lambda.y * sq(R.x.y) + Lambda.z * sq(R.x.z);
-    A12[] = Lambda.x * R.x.x * R.y.x + Lambda.y * R.x.y * R.y.y + Lambda.z * R.x.z * R.y.z;
-    A13[] = Lambda.x * R.x.x * R.z.x + Lambda.y * R.x.y * R.z.y + Lambda.z * R.x.z * R.z.z;
-    A22[] = Lambda.x * sq(R.y.x) + Lambda.y * sq(R.y.y) + Lambda.z * sq(R.y.z);
-    A23[] = Lambda.x * R.y.x * R.z.x + Lambda.y * R.y.y * R.z.y + Lambda.z * R.y.z * R.z.z;
-    A33[] = Lambda.x * sq(R.z.x) + Lambda.y * sq(R.z.y) + Lambda.z * sq(R.z.z);
+    A.x.x = Lambda.x * sq(R.x.x) + Lambda.y * sq(R.x.y) + Lambda.z * sq(R.x.z);
+    A.x.y = Lambda.x * R.x.x * R.y.x + Lambda.y * R.x.y * R.y.y + Lambda.z * R.x.z * R.y.z;
+    A.y.x = A.x.y;
+    A.x.z = Lambda.x * R.x.x * R.z.x + Lambda.y * R.x.y * R.z.y + Lambda.z * R.x.z * R.z.z;
+    A.z.x = A.x.z;
+    A.y.y = Lambda.x * sq(R.y.x) + Lambda.y * sq(R.y.y) + Lambda.z * sq(R.y.z);
+    A.y.z = Lambda.x * R.y.x * R.z.x + Lambda.y * R.y.y * R.z.y + Lambda.z * R.y.z * R.z.z;
+    A.z.y = A.y.z;
+    A.z.z = Lambda.x * sq(R.z.x) + Lambda.y * sq(R.z.y) + Lambda.z * sq(R.z.z);
 
     // Apply relaxation using the relaxation time lambda
     double intFactor = lambda[] != 0. ? exp(-dt/lambda[]) : 0.;
-    
-    A11[] = 1. + (A11[] - 1.)*intFactor;
-    A22[] = 1. + (A22[] - 1.)*intFactor;
-    A33[] = 1. + (A33[] - 1.)*intFactor;
-    A12[] *= intFactor;
-    A13[] *= intFactor;
-    A23[] *= intFactor;
+
+    A.x.y *= intFactor;
+    A.y.x = A.x.y;
+    A.x.z *= intFactor;
+    A.z.x = A.x.z;
+    A.y.z *= intFactor;
+    A.z.y = A.y.z;
+    foreach_dimension()
+      A.x.x = 1. + (A.x.x - 1.)*intFactor;
+
+    /*
+    Get Aij from A. These commands might look repetitive. But, I do this so that in the future, generalization to tensor only form is easier.
+    */
+
+    // diagonal terms:
+    A11[] = A.x.x;
+    A22[] = A.y.y;
+    A33[] = A.z.z;
+    // off-diagonal terms:
+    A12[] = A.x.y;
+    A13[] = A.x.z;
+    A23[] = A.y.z;
 
     // Compute the stress tensor T using the polymer modulus Gp
-    T11[] = Gp[]*(A11[] - 1.);
-    T22[] = Gp[]*(A22[] - 1.);
-    T33[] = Gp[]*(A33[] - 1.);
-    T12[] = Gp[]*A12[];
-    T13[] = Gp[]*A13[];
-    T23[] = Gp[]*A23[];
+    T11[] = Gp[]*(A.x.x - 1.);
+    T22[] = Gp[]*(A.y.y - 1.);
+    T33[] = Gp[]*(A.z.z - 1.);
+    T12[] = Gp[]*A.x.y;
+    T13[] = Gp[]*A.x.z;
+    T23[] = Gp[]*A.y.z;
   }
 }
 #endif

--- a/src-local/log-conform-viscoelastic-scalar-3D.h
+++ b/src-local/log-conform-viscoelastic-scalar-3D.h
@@ -407,6 +407,16 @@ event tracer_advection(i++)
     pseudo_t R;
     init_pseudo_t(&R, 0.0);
     diagonalization_2D (&Lambda, &R, &A);
+
+    /*
+    Check for negative eigenvalues -- this should never happen. If it does, print the location and value of the offending eigenvalue.
+    Please report this bug by opening an issue on the GitHub repository. 
+    */
+    if (Lambda.x <= 0. || Lambda.y <= 0.) {
+      fprintf(ferr, "Negative eigenvalue detected: Lambda.x = %g, Lambda.y = %g\n", Lambda.x, Lambda.y);
+      fprintf(ferr, "x = %g, y = %g, f = %g\n", x, y, f[]);
+      exit(1);
+    }
     
     /**
     $\Psi = \log \mathbf{A}$ is easily obtained after diagonalization, 


### PR DESCRIPTION
This pull request includes the following key changes:

1. Fixed a typo in the documentation of the `log-conform-viscoelastic-scalar-3D.h` file.
2. Added detailed documentation and explanation of the log-conformation method for viscoelastic fluids in the `log-conform-viscoelastic-scalar-2D.h` file. This includes synchronizing the documentation and code changes with the 3D version of the same code.
3. Added a check for negative eigenvalues in the `diagonalization_2D` function and a TODO item to transition to a fully tensor-based formulation.
4. Added new functions `init_pseudo_v` and `init_pseudo_t` to initialize the `pseudo_v` and `pseudo_t` structs, respectively.
5. Improved the computation of the B tensor components and the transformation of the rotation tensor Omega to the original coordinate system.
6. Refactored tensor operations to use an intermediate tensor structure `A` for improved clarity and maintainability, and enforced explicit symmetry in tensor operations.

The goal of these changes is to improve the readability, maintainability, and robustness of the log-conformation viscoelastic solver code.