### PR TITLE
:wrench: feat(viscoelastic): Update conformation tensor fields

### DIFF
--- a/src-local/log-conform-viscoelastic-scalar-2D.h
+++ b/src-local/log-conform-viscoelastic-scalar-2D.h
@@ -174,7 +174,7 @@ TODO:
 scalar A11[], A12[], A22[]; // conformation tensor
 scalar T11[], T12[], T22[]; // stress tensor
 #if AXI
-scalar Aqq[], T_ThTh[];
+scalar AThTh[], T_ThTh[];
 #endif
 
 event defaults (i = 0) {


### PR DESCRIPTION
Updates the conformation tensor fields in the 2D viscoelastic
scalar solver. The `Aqq` field has been renamed to `AThTh` to
better represent the tangential component of the conformation
tensor in axisymmetric coordinates.